### PR TITLE
ROCm6.0 hipamd runtime changes to support Kernel Fusion

### DIFF
--- a/hipamd/src/hip_graph_fuse_recorder.cpp
+++ b/hipamd/src/hip_graph_fuse_recorder.cpp
@@ -260,9 +260,12 @@ GraphFuseRecorder::KernelDescriptions GraphFuseRecorder::collectImages(
     descr.name = kernel->name();
     rtrim(descr.name);
 
-    for (auto& argDescriptor : kernel->signature().parameters()) {
+    auto& kernelargs = kernel->signature().parameters();
+    for (uint32_t i = 0; i < kernel->signature().numParametersAll(); ++i) {
+      auto& argDescriptor = kernelargs[i];
       descr.argsSizes.push_back(argDescriptor.size_);
-      descr.argsTypes.push_back(argDescriptor.type_);
+      const auto& it = kernel->signature().at(i);
+      descr.argsTypes.push_back(it.info_.oclObject_);
     }
 
     auto& program = kernel->program();

--- a/hipamd/src/hip_graph_modifier.cpp
+++ b/hipamd/src/hip_graph_modifier.cpp
@@ -230,20 +230,6 @@ void GraphModifier::generateFusedNodes() {
   }
 }
 
-void GraphModifier::adjustNodeLevels() {
-  // roots node must be grabbed firt - i.e., before modifying node levels
-  /*
-  const auto& roots = graph_->GetRootNodes();
-  const auto& nodes = graph_->GetNodes();
-  for (auto& node: nodes) {
-    node->SetLevel(0);
-  }
-  for (auto& root: roots) {
-    root->UpdateEdgeLevel();
-  }
-  */
-}
-
 void GraphModifier::run() {
   amd::ScopedLock lock(fclock_);
   currDescription = descriptions_[instanceId_];
@@ -268,7 +254,7 @@ void GraphModifier::run() {
       const auto& dependencies = groupHead->GetDependencies();
       std::vector<Node> additionalEdges{fusedNode};
       for (const auto& dependency : dependencies) {
-        dependency->RemoveEdge(groupHead);
+        dependency->RemoveUpdateEdge(groupHead);
         dependency->AddEdge(fusedNode);
       }
     }
@@ -277,7 +263,7 @@ void GraphModifier::run() {
     if (groupTail) {
       const auto& edges = groupTail->GetEdges();
       for (const auto& edge : edges) {
-        edge->RemoveDependency(groupTail);
+        groupTail->RemoveUpdateEdge(edge);
         fusedNode->AddEdge(edge);
       }
     }
@@ -288,6 +274,5 @@ void GraphModifier::run() {
     }
     graph_->AddNode(fusedNode);
   }
-  adjustNodeLevels();
 }
 }  // namespace hip


### PR DESCRIPTION
This PR has the following changes:

1. Update graph recorder to also record the kernel hidden argument types
2. Shuffle kernel arguments such that hidden arguments get pushed to the end
3. Update graph modifier such that graph edges are computes correctly